### PR TITLE
fix/socket duplicated socket instance

### DIFF
--- a/src/pages/Game/index.js
+++ b/src/pages/Game/index.js
@@ -10,7 +10,7 @@ const Game = () => {
   const { state } = useContext(UserContext);
 
   useEffect(() => {
-    Socket.initInstance(state.user.userId);
+    Socket.connect(state.user.userId);
   }, [state]);
 
   return (

--- a/src/utils/socket/index.js
+++ b/src/utils/socket/index.js
@@ -1,19 +1,27 @@
 import { LOCAL_SERVER } from '@/constants';
 import io from '@/package/socket';
 
-const Socket = {
-  socketInstance: undefined,
-  initInstance(userId) {
-    this.socketInstance = io(LOCAL_SERVER, {
-      query: {
-        userId,
-      },
-    });
-  },
+class Socket {
+  static socketInstance;
 
-  getInstance() {
-    return this.socketInstance; // initInstance가 수행되지 않으면 undefined가 반환된다
-  },
-};
+  static getInstance() {
+    if (!Socket.socketInstance) {
+      Socket.socketInstance = io(LOCAL_SERVER, {
+        autoConnect: false,
+      });
+    }
+    return Socket.socketInstance;
+  }
+
+  static connect(userId) {
+    if (!userId) {
+      console.error('can not connect socket because userId is undefined');
+      return;
+    }
+    const socketInstance = Socket.getInstance();
+    socketInstance.io.opts.query = { userId };
+    socketInstance.connect();
+  }
+}
 
 export default Socket;


### PR DESCRIPTION
## 설명

소켓 인스턴스가 두번 생성되는 버그를 수정하였습니다. 의존성 배열의 state를 제거함으로써 버그 수정이 가능하지만, 추후에 채팅 관련한 작업에서 문제가 생길 수 있어서 다른 방향으로 버그를 수정하였습니다.

`Socket`을 필요로 하는 모든 곳에서 오직 하나의 `SocketInstance` 받되, 연결을 하지 않고 있다가 `connect` 함수를 통해 `userId`를 담은 연결을 시도함으로써 `connect` 이전과 이후 어디에서도 단 하나의 소켓 인스턴스를 가지도록 작업하였습니다. 즉 소켓의 인스턴스의 생성과 연결을 분리했다고 보시면 될 것 같습니다!

## 테스트

- [x] 로컬 테스트 진행
<!--로컬 테스트를 진행하고 나서 pr을 올려주세요. -->

## 관련 이슈

fix #74 

<!--close,fix,release 중 하나를 선택해서 작성해주세요. 대괄호는 삭제해주세요. 이슈가 여러개일 경우 s를 끝에 붙여주세요.-->

## Breaking Change

- [ ] yes
- [x] no

<!--의존성, env 파일 등등의 변화로 기존 버전과 호환이 안되는 경우 yes에 체크해주세요-->
