### PR TITLE
hotfix/socket duplicated socket

### DIFF
--- a/src/utils/socket/index.js
+++ b/src/utils/socket/index.js
@@ -4,6 +4,8 @@ import io from '@/package/socket';
 class Socket {
   static socketInstance;
 
+  static isConnected = false;
+
   static getInstance() {
     if (!Socket.socketInstance) {
       Socket.socketInstance = io(LOCAL_SERVER, {
@@ -14,13 +16,16 @@ class Socket {
   }
 
   static connect(userId) {
-    if (!userId) {
-      console.error('can not connect socket because userId is undefined');
+    if (!userId || Socket.isConnected) {
       return;
     }
     const socketInstance = Socket.getInstance();
     socketInstance.io.opts.query = { userId };
     socketInstance.connect();
+    Socket.isConnected = true;
+    socketInstance.on('connect_error', () => {
+      Socket.isConnected = false;
+    });
   }
 }
 


### PR DESCRIPTION
## 설명

- 소켓이 두번 연결되는 이슈가 있어서 해결 하였습니다. 이슈가 발생한 이유를 말하자면,

- 우선 로그인과정에서 state의 action이 두번 일어납니다. 때문에 useEffect의 의존성으로 state를 추가하면 로그인에 의해 useEffect는 두번 수행하게 됩니다.
- 초기에는 `socketInstance.connected` 값을 통해서 연결되어있지 않은 경우에만 socket connect를 수행하려고 하였습니다. 하지만 또 다른 이슈가 있었는데 socket manager가 연결을 수행하고 성공해서 connected값을 변경하기전에 useEffect가 두번이나 수행되다보니, 연결이 두번되는 문제가 있었습니다.
- 해당 이슈를 고민을 하였는데, 일단 불가피하게 Socket 객체에 연결상태인 `isConnected` 상태를 만들어주었습니다. 연결직전에 해당 상태를 바꾸고 만약, 연결이 실패했을때에는 상태변경을 롤백시켜주는 쪽으로 작업하였습니다.
- 위 방법으로 소켓은 언제어느때나 connect를 여러번 시도하더라도 오직하나의 connect를 수행하지만 관리해야하는 Socket의 프로퍼티가 하나 더 늘어나게 된 것 같습니다.
- 추후에 더 좋은 해결책이 떠오르면 개선하도록 하겠습니다!

## 테스트

- [x] 로컬 테스트 진행
<!--로컬 테스트를 진행하고 나서 pr을 올려주세요. -->

## 관련 이슈

fix #76 

<!--close,fix,release 중 하나를 선택해서 작성해주세요. 대괄호는 삭제해주세요. 이슈가 여러개일 경우 s를 끝에 붙여주세요.-->

## Breaking Change

- [ ] yes
- [x] no

<!--의존성, env 파일 등등의 변화로 기존 버전과 호환이 안되는 경우 yes에 체크해주세요-->
